### PR TITLE
Add debug logging in sdk for launch params

### DIFF
--- a/packages/sdk/src/init/init.ts
+++ b/packages/sdk/src/init/init.ts
@@ -15,6 +15,7 @@ import {
 import {InitOptions, InitResult} from './types';
 import {retrieveLaunchParams} from './launch-params';
 import {BridgeScoped} from '../lib';
+import {setupLogger} from "../utils/logging";
 
 /**
  * Initializes all SDK components.
@@ -22,6 +23,8 @@ import {BridgeScoped} from '../lib';
  */
 async function init(options: InitOptions = {}): Promise<InitResult> {
   const {checkCompat = true} = options;
+
+  setupLogger(options);
 
   // Get Web App data.
   const {
@@ -66,13 +69,13 @@ async function init(options: InitOptions = {}): Promise<InitResult> {
     height,
     isStateStable,
   } = platform !== 'tdesktop' && platform !== 'macos'
-    ? await Viewport.request(bridge)
-    : {
-      width: window.innerWidth,
-      height: window.innerHeight,
-      isStateStable: true,
-      isExpanded: true,
-    };
+      ? await Viewport.request(bridge)
+      : {
+        width: window.innerWidth,
+        height: window.innerHeight,
+        isStateStable: true,
+        isExpanded: true,
+      };
 
   return {
     backButton: new BackButton(bridge, version),
@@ -86,7 +89,7 @@ async function init(options: InitOptions = {}): Promise<InitResult> {
     qrScanner: new QRScanner(bridge, version),
     themeParams: ThemeParams.synced(bridge, themeParams),
     viewport: Viewport.synced(
-      bridge, height, width, isStateStable ? height : 0, isExpanded,
+        bridge, height, width, isStateStable ? height : 0, isExpanded,
     ),
     webApp: new WebApp(bridge, version, platform),
   };

--- a/packages/sdk/src/init/launch-params.ts
+++ b/packages/sdk/src/init/launch-params.ts
@@ -1,9 +1,9 @@
-/* eslint-disable no-empty */
 import {createSearchParamsParser} from '@twa.js/utils';
 import {parseInitData, InitData} from '@twa.js/init-data';
 
 import {parseThemeParams, ThemeParams} from '../utils';
 import {Platform} from '../components';
+import {debugLog} from "../utils/logging";
 
 interface LaunchParams {
   version: string;
@@ -35,6 +35,8 @@ function retrieveLaunchParams(): LaunchParams {
 
     return webAppData;
   } catch (e) {
+    const initParams = window.location.hash.slice(1);
+    debugLog('log', `Can't parse launch params from search params`, initParams, e);
   }
 
   // Web Apps allows reloading current page. In this case,
@@ -44,6 +46,7 @@ function retrieveLaunchParams(): LaunchParams {
   try {
     return parseLaunchParams(sessionStorage.getItem(sessionStorageKey) || '');
   } catch (e) {
+    debugLog('log', `Can't parse launch params from session storage`, sessionStorage.getItem(sessionStorageKey), e);
   }
   throw new Error('Unable to extract launch params.');
 }

--- a/packages/sdk/src/utils/logging.ts
+++ b/packages/sdk/src/utils/logging.ts
@@ -1,0 +1,18 @@
+import {log as utilsLog} from '@twa.js/utils';
+import {InitOptions} from "../init";
+
+let isDebug = false;
+
+const setupLogger = (options: InitOptions) => {
+    if (options.debug) {
+        isDebug = options.debug
+    }
+};
+
+const debugLog: typeof utilsLog = (level, ...args) => {
+    if (isDebug) {
+        utilsLog(level, '[SDK]', ...args);
+    }
+}
+
+export {debugLog, setupLogger}


### PR DESCRIPTION
We don't have enough logging here, so I added a global `debugLog` function. 

Unsolved problem: production build will include such logging. I tried to prune it in `terser` rollup plugin, but didn't figure out, how I could keep it only for dev (probably we don't have such distinction right now). Tried `terser({ compress: { pure_funcs: ['debugLog'] } })`